### PR TITLE
Add Departments of Homeland Security, Energy, Labor, Education

### DIFF
--- a/urls.txt
+++ b/urls.txt
@@ -9,3 +9,4 @@ https://data.cdc.gov/data.json
 https://open.gsa.gov/data.json
 https://open.fda.gov/data.json
 https://www.dhs.gov/data.json
+https://www.energy.gov/data.json

--- a/urls.txt
+++ b/urls.txt
@@ -8,3 +8,4 @@ https://www.justice.gov/data.json
 https://data.cdc.gov/data.json
 https://open.gsa.gov/data.json
 https://open.fda.gov/data.json
+https://www.dhs.gov/data.json

--- a/urls.txt
+++ b/urls.txt
@@ -10,3 +10,4 @@ https://open.gsa.gov/data.json
 https://open.fda.gov/data.json
 https://www.dhs.gov/data.json
 https://www.energy.gov/data.json
+https://www.dol.gov/data.json

--- a/urls.txt
+++ b/urls.txt
@@ -11,3 +11,4 @@ https://open.fda.gov/data.json
 https://www.dhs.gov/data.json
 https://www.energy.gov/data.json
 https://www.dol.gov/data.json
+https://data.ed.gov/data.json


### PR DESCRIPTION
This PR adds data.json URL sources for the Departments of Homeland Security, Energy, Labor, and Education based on this set of [Data.gov sources](https://catalog.data.gov/harvest/?source_type=datajson&organization_type=Federal+Government&_organization_limit=0).